### PR TITLE
【WIP】Chatspace READMEにDB設計

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,4 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Things you may want to cover:
 ### Association
 has_many :messages
 has_many :groups, through: :groups_users
+has_many :groups_users
 
 ## groupテーブル
 
@@ -43,6 +44,7 @@ has_many :groups, through: :groups_users
 ### Association
 has_many :users, through: :groups_users
 has_many :messages
+has_many :groups_users
 
 ## messageテーブル
 
@@ -51,7 +53,7 @@ has_many :messages
 |user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|
 |image|string| |
-|body|text|null: false |
+|body|text|
 
 ### Association
 belongs_to :user

--- a/README.md
+++ b/README.md
@@ -23,3 +23,51 @@ Things you may want to cover:
 
 * ...
 
+## userテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+|name|string|null: false|
+|mail _address|string|null:false, unique: true|
+
+### Association
+has_many :messages
+has_many :groups
+
+## groupsテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+|group_name|string|null: false|
+
+### Association
+belongs_to :user
+
+## messagesテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|message_id|integer|null: false, foreign_key |
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+|image|string| |
+|body|text|null: false |
+
+### Association
+belongs_to :user
+belongs_to :group
+
+## groups_usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :group
+- belongs_to :user

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Things you may want to cover:
 
 ### Association
 has_many :messages
-has_many :groups
+has_many :groups, through: :groups_users
 
 ## groupsテーブル
 
@@ -45,7 +45,8 @@ has_many :groups
 |group_name|string|null: false|
 
 ### Association
-belongs_to :user
+has_many :user, through: :groups_users
+has_many :messages
 
 ## messagesテーブル
 
@@ -69,5 +70,5 @@ belongs_to :group
 |group_id|integer|null: false, foreign_key: true|
 
 ### Association
-- belongs_to :group
+- belomgs_to :group
 - belongs_to :user

--- a/README.md
+++ b/README.md
@@ -27,32 +27,27 @@ Things you may want to cover:
 
 |Column|Type|Options|
 |------|----|-------|
-|user_id|integer|null: false, foreign_key: true|
-|group_id|integer|null: false, foreign_key: true|
 |name|string|null: false|
 |mail _address|string|null:false, unique: true|
 
 ### Association
 has_many :messages
-has_many :groups, through: :groups_users
+has_many :group, through: :groups_users
 
-## groupsテーブル
+## groupテーブル
 
 |Column|Type|Options|
 |------|----|-------|
-|user_id|integer|null: false, foreign_key: true|
-|group_id|integer|null: false, foreign_key: true|
-|group_name|string|null: false|
+|name|string|null: false|
 
 ### Association
 has_many :user, through: :groups_users
-has_many :messages
+has_many :message
 
-## messagesテーブル
+## messageテーブル
 
 |Column|Type|Options|
 |------|----|-------|
-|message_id|integer|null: false, foreign_key |
 |user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|
 |image|string| |
@@ -70,5 +65,5 @@ belongs_to :group
 |group_id|integer|null: false, foreign_key: true|
 
 ### Association
-- belomgs_to :group
+- belongs_to :group
 - belongs_to :user

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Things you may want to cover:
 
 ### Association
 has_many :messages
-has_many :group, through: :groups_users
+has_many :groups, through: :groups_users
 
 ## groupテーブル
 
@@ -41,8 +41,8 @@ has_many :group, through: :groups_users
 |name|string|null: false|
 
 ### Association
-has_many :user, through: :groups_users
-has_many :message
+has_many :users, through: :groups_users
+has_many :messages
 
 ## messageテーブル
 


### PR DESCRIPTION
# What
ChatspaceのDBを設計。
テーブルを４つ作成。usesテーブル、groupsテーブル、messagesテーブル、groups_usersテーブル。
各テーブルにカラムを作成。カラム構成は、usersテーブル（user_id,group_id,name,mail_address）groupsテーブル（user_id,group_id,group_name）、messagesテーブル（message_id,user_id,group_id,image,body）、groups_users（user_id,group_id）である。
各アソシエーションはusersテーブルhas_many :messages
has_many :groups。groupsテーブルbelong_to :user。messageテーブルbelongs_to :user belongs_to :group。groups_usersテーブルbelongs_to :group belongs_to :userである。

# Why
ChatspaceでのDB設計によりユーザーやメッセージの管理を可能にするため。

